### PR TITLE
Modifiche per rendere i test case indipendenti. Piccolo refactoring del codice

### DIFF
--- a/spring-cache/src/test/java/com/luigimoro/spring/tutorial/cache/service/CustomerServiceTest.java
+++ b/spring-cache/src/test/java/com/luigimoro/spring/tutorial/cache/service/CustomerServiceTest.java
@@ -4,14 +4,13 @@ import com.luigimoro.spring.tutorial.cache.configuration.AppConfig;
 import com.luigimoro.spring.tutorial.cache.dao.model.CustomerModel;
 import com.luigimoro.spring.tutorial.cache.dao.repository.CustomerRepository;
 import com.luigimoro.spring.tutorial.cache.dto.CustomerInfo;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import redis.embedded.RedisServer;
@@ -21,19 +20,14 @@ import java.io.IOException;
 import static org.mockito.Mockito.*;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(classes = {AppConfig.class, CustomerServiceTest.TestConfig.class})
+@Configuration
+@Import(AppConfig.class)
+@ContextConfiguration(classes = {CustomerServiceTest.class})
 public class CustomerServiceTest {
 
-
-    private static final String CUSTOMER_ID = "1234567";
-
-    @Configuration
-    static class TestConfig {
-
-        @Bean
-        CustomerRepository customerRepository() {
-            return mock(CustomerRepository.class);
-        }
+    @Bean
+    public CustomerRepository customerRepository() {
+        return mock(CustomerRepository.class);
     }
 
     @Autowired
@@ -42,48 +36,49 @@ public class CustomerServiceTest {
     @Autowired
     CustomerRepository customerRepository;
 
-    private static RedisServer server = null;
+    private static RedisServer server;
 
-
-    @Before
-    public void setup() throws IOException {
+    @BeforeClass
+    public static void setup() throws IOException {
         server = new RedisServer();
         server.start();
     }
 
-    @After
-    public void teardown() {
+    @AfterClass
+    public static void teardown() {
         server.stop();
     }
 
     @Test
-    public void testGetCustomerInfoImplementaionExecutedOnlyOnce() {
+    public void testGetCustomerInfoImplementationExecutedOnlyOnce() {
+        final String ONLY_ONCE_CUSTOMER_ID = "ONLY_ONCE_CUSTOMER_ID";
 
-        when(customerRepository.findCustomerModelByCustomerId(Mockito.anyString())).thenReturn(new CustomerModel("Mario", "Giordano"));
+        when(customerRepository.findCustomerModelByCustomerId(ONLY_ONCE_CUSTOMER_ID)).thenReturn(new CustomerModel("Mario", "Giordano"));
 
-        customerService.getCustomerInfo(CUSTOMER_ID);
+        customerService.getCustomerInfo(ONLY_ONCE_CUSTOMER_ID);
 
-        customerService.getCustomerInfo(CUSTOMER_ID);
+        customerService.getCustomerInfo(ONLY_ONCE_CUSTOMER_ID);
 
-        verify(customerRepository, times(1)).findCustomerModelByCustomerId(CUSTOMER_ID);
+        verify(customerRepository, times(1)).findCustomerModelByCustomerId(ONLY_ONCE_CUSTOMER_ID);
     }
 
     @Test
-    public void testGetCustomerInfoImplementaionExecutedTwoTimes() {
+    public void testGetCustomerInfoImplementationExecutedTwoTimes() {
+        String TWO_TIMES_CUSTOMER_ID = "TWO_TIMES_CUSTOMER_ID";
 
         CustomerInfo customerInfo = new CustomerInfo();
-        customerInfo.setCustomerId(CUSTOMER_ID);
+        customerInfo.setCustomerId(TWO_TIMES_CUSTOMER_ID);
         customerInfo.setName("Mario");
         customerInfo.setSurname("Rossi");
 
-        when(customerRepository.findCustomerModelByCustomerId(Mockito.anyString())).thenReturn(new CustomerModel("Mario", "Giordano"));
+        when(customerRepository.findCustomerModelByCustomerId(TWO_TIMES_CUSTOMER_ID)).thenReturn(new CustomerModel("Mario", "Giordano"));
 
-        customerService.getCustomerInfo(CUSTOMER_ID);
+        customerService.getCustomerInfo(TWO_TIMES_CUSTOMER_ID );
 
         customerService.updateCustomerInfo(customerInfo);
 
-        customerService.getCustomerInfo(CUSTOMER_ID);
+        customerService.getCustomerInfo(TWO_TIMES_CUSTOMER_ID);
 
-        verify(customerRepository, times(2)).findCustomerModelByCustomerId(CUSTOMER_ID);
+        verify(customerRepository, times(2)).findCustomerModelByCustomerId(TWO_TIMES_CUSTOMER_ID);
     }
 }


### PR DESCRIPTION
Utilizzando customerId differenti per ogni Test li rendiamo indipendenti dall'altro.
Inoltre la cache in memory adesso è condivisa tra più test case (opinabile, ma meno overhead), ma utilizzando un ID differente in ogni TC, questi non si pestano i piedi a vicenda.

L'alternativa sarebbe quella di tornare ad una cache inizializzata per ogni test ed invocare clearInvocations(T... mocks) nel @Before method.